### PR TITLE
add MCN support

### DIFF
--- a/image_id.c
+++ b/image_id.c
@@ -96,7 +96,7 @@ static bool process_disc(MirageDisc *disc, DiscId *discid) {
 	char mcn[13+1] = "\0";
 
 	if (mirage_disc_get_mcn(disc) != NULL) {
-		strncpy(mcn, (char *) mirage_disc_get_mcn(disc), sizeof mcn);
+		strncpy(mcn, mirage_disc_get_mcn(disc), sizeof mcn);
 	}
 
 	sessions = mirage_disc_get_number_of_sessions(disc);

--- a/image_id.c
+++ b/image_id.c
@@ -91,6 +91,9 @@ static bool process_disc(MirageDisc *disc, DiscId *discid) {
 
 	int first, last;
 	int offsets[100] = {0};
+	char mcn[13+1] = "\0";
+
+	strncpy(mcn, (char *) mirage_disc_get_mcn(disc), sizeof mcn);
 
 	sessions = mirage_disc_get_number_of_sessions(disc);
 	fprintf(stderr, "Disc contains %d sessions\n", sessions);
@@ -178,6 +181,7 @@ static bool process_disc(MirageDisc *disc, DiscId *discid) {
 
 	fprintf(stderr, "FreeDB: %s\n", discid_get_freedb_id(discid));
 	fprintf(stderr, "%s\n", discid_get_submission_url(discid));
+	fprintf(stderr, "MCN: %s\n", mcn);
 
 	return true;
 }

--- a/image_id.c
+++ b/image_id.c
@@ -93,7 +93,9 @@ static bool process_disc(MirageDisc *disc, DiscId *discid) {
 	int offsets[100] = {0};
 	char mcn[13+1] = "\0";
 
-	strncpy(mcn, (char *) mirage_disc_get_mcn(disc), sizeof mcn);
+	if (mirage_disc_get_mcn(disc) != NULL) {
+		strncpy(mcn, (char *) mirage_disc_get_mcn(disc), sizeof mcn);
+	}
 
 	sessions = mirage_disc_get_number_of_sessions(disc);
 	fprintf(stderr, "Disc contains %d sessions\n", sessions);
@@ -181,7 +183,9 @@ static bool process_disc(MirageDisc *disc, DiscId *discid) {
 
 	fprintf(stderr, "FreeDB: %s\n", discid_get_freedb_id(discid));
 	fprintf(stderr, "%s\n", discid_get_submission_url(discid));
-	fprintf(stderr, "MCN: %s\n", mcn);
+	if (strlen(mcn) > 0) {
+		fprintf(stderr, "MCN: %s\n", mcn);
+	}
 
 	return true;
 }


### PR DESCRIPTION
Similar to ISRC support, except there is not a direct use case yet.

python-discid/libdiscid also provides the MCN, but isrcsubmit ignores this information currently.
