### PR TITLE
print debug out only when DEBUG is set

### DIFF
--- a/image_id.c
+++ b/image_id.c
@@ -31,6 +31,8 @@
 #define VERSION "1.0"
 #define COPYRIGHT "Copyright (c) 2013 Calvin Walton"
 
+#define DEBUG 0
+
 /* Print the version information for the program */
 static void print_version();
 /* Print the usage information for the program */
@@ -114,18 +116,26 @@ static bool process_disc(MirageDisc *disc, DiscId *discid) {
 		start_sector = mirage_session_layout_get_start_sector(session);
 		length = mirage_session_layout_get_length(session);
 
-		fprintf(stderr, "session %d: layout: number %d, first track %d, start sector %d, length %d\n",
-				i, session_number, first_track, start_sector, length);
+		if (DEBUG) {
+			fprintf(stderr, "session %d: layout: number %d, first track %d, start sector %d, length %d\n",
+				i, session_number, first_track, start_sector,
+				length);
+		}
 
 		type = mirage_session_get_session_type(session);
 		leadout_length = mirage_session_get_leadout_length(session);
 		tracks = mirage_session_get_number_of_tracks(session);
 
-		fprintf(stderr, "session %d: %d tracks, type %d, leadout length %d\n",
+		if (DEBUG) {
+			fprintf(stderr, "session %d: %d tracks, type %d, leadout length %d\n",
 				i, tracks, type, leadout_length);
+		}
 
 		offset = 0 - start_sector;
-		fprintf(stderr, "session %d: calculated offset %d\n", i, offset);
+		if (DEBUG) {
+			fprintf(stderr, "session %d: calculated offset %d\n",
+				i, offset);
+		}
 
 		offsets[0] = length;
 		first = last = first_track;
@@ -146,16 +156,23 @@ static bool process_disc(MirageDisc *disc, DiscId *discid) {
 			track_start_sector = mirage_track_layout_get_start_sector(track);
 			track_length = mirage_track_layout_get_length(track);
 
-			fprintf(stderr, "session %d: track %d: layout: number %d, start sector %d, length %d\n",
-					i, j, track_num, track_start_sector + offset, track_length);
+			if (DEBUG) {
+				fprintf(stderr, "session %d: track %d: layout: number %d, start sector %d, length %d\n",
+					i, j, track_num,
+					track_start_sector + offset,
+					track_length);
+			}
 
 			track_start = mirage_track_get_track_start(track);
 			indices = mirage_track_get_number_of_indices(track);
 
-			fprintf(stderr, "session %d: track %d: track start %d, %d indicies\n",
+			if (DEBUG) {
+				fprintf(stderr, "session %d: track %d: track start %d, %d indicies\n",
 					i, j,
-					track_start + track_start_sector + offset,
+					track_start + track_start_sector
+						    + offset,
 					indices);
+			}
 
 			offsets[track_num] = track_start + track_start_sector + offset;
 			if (track_num > last)


### PR DESCRIPTION
I personally think we coun't print more to stdout than the disc ID without breaking tools using image-id.

However, we should probably make the stderr output less verbose.
This removes messages that are mostly interesting for debugging.
They can be re-enabled by setting `#define DEBUG 1`.
