### PR TITLE
always initialize first and last

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 RM=rm -f
-CFLAGS=-g -Wall
+CFLAGS=-g -Wall -O
 
 IMAGE_ID_LIBS:=$(shell pkg-config --libs libdiscid 'libmirage >= 2.0.0')
 IMAGE_ID_CFLAGS:=-std=c99 $(shell pkg-config --cflags libdiscid 'libmirage >= 2.0.0')

--- a/image_id.c
+++ b/image_id.c
@@ -91,7 +91,8 @@ static bool process_disc(MirageDisc *disc, DiscId *discid) {
 	int sessions;
 	GError *error = NULL;
 
-	int first, last;
+	int first = 1;
+	int last = 0;
 	int offsets[100] = {0};
 	char isrcs[100][MIRAGE_ISRC_SIZE+1] = {{0}};
 	char mcn[MIRAGE_MCN_SIZE+1] = "\0";


### PR DESCRIPTION
With CFLAG -O and -Wall this gives a "maybe uninitialized" warning:

```
gcc -c -std=c99 -pthread -I/usr/include/libmirage -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include  -g -Wall -O  image_id.c -o image_id.o
image_id.c: In function 'process_disc':
image_id.c:200:2: warning: 'last' may be used uninitialized in this function [-Wmaybe-uninitialized]
  for (int i = first; i <= last; i++) {
  ^
image_id.c:205:12: warning: 'first' may be used uninitialized in this function [-Wmaybe-uninitialized]
  discid_put(discid, first, last, offsets);
            ^
```
